### PR TITLE
Cookie domain now set correctly

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 type Config struct {
 	BindAddr                   string        `envconfig:"BIND_ADDR"`
 	RendererURL                string        `envconfig:"RENDERER_URL"`
+	SiteDomain                 string        `envconfig:"SITE_DOMAIN"`
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
@@ -25,6 +26,7 @@ func Get() (*Config, error) {
 	cfg := &Config{
 		BindAddr:                   ":24100",
 		RendererURL:                "http://localhost:20010",
+		SiteDomain:                 "localhost",
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckInterval:        10 * time.Second,
 		HealthCheckCriticalTimeout: time.Minute,

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"dp-frontend-cookie-controller/config"
 	"dp-frontend-cookie-controller/mapper"
 	"encoding/json"
 	"errors"
@@ -92,9 +91,9 @@ func removeNonProtectedCookies(w http.ResponseWriter, req *http.Request) {
 
 // AcceptAll handler for setting all cookies to enabled then refresh the page. when JS has been disabled
 // Example usage; JavaScript disabled.
-func AcceptAll(cfg config.Config) http.HandlerFunc {
+func AcceptAll(siteDomain string) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		acceptAll(w, req, cfg.SiteDomain)
+		acceptAll(w, req, siteDomain)
 	}
 }
 
@@ -106,30 +105,34 @@ func Read(rendC RenderClient) http.HandlerFunc {
 }
 
 // Edit Handler
-func Edit(rendC RenderClient, cfg config.Config) http.HandlerFunc {
+func Edit(rendC RenderClient, siteDomain string) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		edit(w, req, rendC, cfg.SiteDomain)
+		edit(w, req, rendC, siteDomain)
 	}
 }
 
 // acceptAll handler for accepting all possible cookies
 func acceptAll(w http.ResponseWriter, req *http.Request, siteDomain string) {
+	log.Event(nil, "acceptAll hit")
 	ctx := req.Context()
 	cp := cookies.Policy{
 		Essential: true,
 		Usage:     true,
 	}
-
+	log.Event(nil, "set policy")
 	cookies.SetPolicy(w, cp, siteDomain)
+	log.Event(nil, "set preferences")
 	cookies.SetPreferenceIsSet(w, siteDomain)
+
 	referer := req.Header.Get("Referer")
+	log.Event(nil, "got referer")
 	if referer == "" {
 		err := errors.New("cannot redirect due to no referer header")
 		log.Event(ctx, "unable to parse url", log.Error(err))
 		setStatusCode(req, w, err)
 		return
 	}
-	log.Event(ctx, "redirecting to "+referer, log.INFO)
+	log.Event(nil, "now redirect")
 	http.Redirect(w, req, referer, http.StatusFound)
 }
 

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"dp-frontend-cookie-controller/config"
 	"encoding/json"
 	"errors"
 	"github.com/ONSdigital/dp-cookies/cookies"
@@ -88,6 +89,11 @@ func protectedCookiesTest(w *httptest.ResponseRecorder) bool {
 // TestUnitHandlers unit tests for all handlers
 func TestUnitHandlers(t *testing.T) {
 	t.Parallel()
+
+	cfg := config.Config{
+		SiteDomain: "ons",
+	}
+
 	Convey("test setStatusCode", t, func() {
 
 		Convey("test status code handles 404 response from client", func() {
@@ -119,7 +125,7 @@ func TestUnitHandlers(t *testing.T) {
 			referer := "https://www.ons.gov.uk"
 			req := httptest.NewRequest("GET", "/cookies/accept-all", nil)
 			req.Header.Set("Referer", referer)
-			w := doTestRequest("/cookies/accept-all", req, AcceptAll(), nil)
+			w := doTestRequest("/cookies/accept-all", req, AcceptAll(cfg), nil)
 
 			So(w.Header().Get("Location"), ShouldEqual, referer)
 			So(w.Code, ShouldEqual, http.StatusFound)
@@ -129,7 +135,7 @@ func TestUnitHandlers(t *testing.T) {
 
 		Convey("is failure no referer header", func() {
 			req := httptest.NewRequest("GET", "/cookies/accept-all", nil)
-			w := doTestRequest("/cookies/accept-all", req, AcceptAll(), nil)
+			w := doTestRequest("/cookies/accept-all", req, AcceptAll(cfg), nil)
 
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		})
@@ -205,7 +211,7 @@ func TestUnitHandlers(t *testing.T) {
 			b := `cookie-policy-usage=true`
 			req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-			w := doTestRequest("/cookies", req, Edit(mockRend), nil)
+			w := doTestRequest("/cookies", req, Edit(mockRend, cfg), nil)
 			So(w.Code, ShouldEqual, http.StatusOK)
 			So(w.Body.String(), ShouldEqual, "<html><body><h1>Some HTML from renderer!</h1></body></html>")
 			cookiePolicyTest(w, cookiesPol)
@@ -231,7 +237,7 @@ func TestUnitHandlers(t *testing.T) {
 			cookies.SetLang(w, lang, "domain")
 			http.SetCookie(w, cookieRememberBasket)
 			http.SetCookie(w, cookieTimeSeriesBasket)
-			w = doTestRequest("/cookies", req, Edit(mockRend), w)
+			w = doTestRequest("/cookies", req, Edit(mockRend, cfg), w)
 			So(w.Code, ShouldEqual, http.StatusOK)
 			So(w.Body.String(), ShouldEqual, "<html><body><h1>Some HTML from renderer!</h1></body></html>")
 			cookiePolicyTest(w, cookiesPol)
@@ -244,7 +250,7 @@ func TestUnitHandlers(t *testing.T) {
 			b := `cookie-policy-waffles=true`
 			req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-			w := doTestRequest("/cookies", req, Edit(mockRend), nil)
+			w := doTestRequest("/cookies", req, Edit(mockRend, cfg), nil)
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		})
 		Convey("fail with bad form values", func() {
@@ -252,7 +258,7 @@ func TestUnitHandlers(t *testing.T) {
 			b := `cookie-policy-usage=nonbool`
 			req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-			w := doTestRequest("/cookies", req, Edit(mockRend), nil)
+			w := doTestRequest("/cookies", req, Edit(mockRend, cfg), nil)
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		})
 		Convey("fail with renderer error", func() {
@@ -260,7 +266,7 @@ func TestUnitHandlers(t *testing.T) {
 			b := `cookie-policy-usage=true`
 			req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-			w := doTestRequest("/cookies", req, Edit(mockRend), nil)
+			w := doTestRequest("/cookies", req, Edit(mockRend, cfg), nil)
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		})
 	})

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -125,7 +125,7 @@ func TestUnitHandlers(t *testing.T) {
 			referer := "https://www.ons.gov.uk"
 			req := httptest.NewRequest("GET", "/cookies/accept-all", nil)
 			req.Header.Set("Referer", referer)
-			w := doTestRequest("/cookies/accept-all", req, AcceptAll(cfg), nil)
+			w := doTestRequest("/cookies/accept-all", req, AcceptAll(cfg.SiteDomain), nil)
 
 			So(w.Header().Get("Location"), ShouldEqual, referer)
 			So(w.Code, ShouldEqual, http.StatusFound)
@@ -135,7 +135,7 @@ func TestUnitHandlers(t *testing.T) {
 
 		Convey("is failure no referer header", func() {
 			req := httptest.NewRequest("GET", "/cookies/accept-all", nil)
-			w := doTestRequest("/cookies/accept-all", req, AcceptAll(cfg), nil)
+			w := doTestRequest("/cookies/accept-all", req, AcceptAll(cfg.SiteDomain), nil)
 
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		})
@@ -211,7 +211,7 @@ func TestUnitHandlers(t *testing.T) {
 			b := `cookie-policy-usage=true`
 			req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-			w := doTestRequest("/cookies", req, Edit(mockRend, cfg), nil)
+			w := doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), nil)
 			So(w.Code, ShouldEqual, http.StatusOK)
 			So(w.Body.String(), ShouldEqual, "<html><body><h1>Some HTML from renderer!</h1></body></html>")
 			cookiePolicyTest(w, cookiesPol)
@@ -237,7 +237,7 @@ func TestUnitHandlers(t *testing.T) {
 			cookies.SetLang(w, lang, "domain")
 			http.SetCookie(w, cookieRememberBasket)
 			http.SetCookie(w, cookieTimeSeriesBasket)
-			w = doTestRequest("/cookies", req, Edit(mockRend, cfg), w)
+			w = doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), w)
 			So(w.Code, ShouldEqual, http.StatusOK)
 			So(w.Body.String(), ShouldEqual, "<html><body><h1>Some HTML from renderer!</h1></body></html>")
 			cookiePolicyTest(w, cookiesPol)
@@ -250,7 +250,7 @@ func TestUnitHandlers(t *testing.T) {
 			b := `cookie-policy-waffles=true`
 			req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-			w := doTestRequest("/cookies", req, Edit(mockRend, cfg), nil)
+			w := doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), nil)
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		})
 		Convey("fail with bad form values", func() {
@@ -258,7 +258,7 @@ func TestUnitHandlers(t *testing.T) {
 			b := `cookie-policy-usage=nonbool`
 			req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-			w := doTestRequest("/cookies", req, Edit(mockRend, cfg), nil)
+			w := doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), nil)
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		})
 		Convey("fail with renderer error", func() {
@@ -266,7 +266,7 @@ func TestUnitHandlers(t *testing.T) {
 			b := `cookie-policy-usage=true`
 			req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-			w := doTestRequest("/cookies", req, Edit(mockRend, cfg), nil)
+			w := doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), nil)
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		})
 	})

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -17,10 +17,11 @@ func Init(ctx context.Context, r *mux.Router, cfg *config.Config, hc health.Heal
 	log.Event(ctx, "adding api routes")
 
 	rendC := renderer.New(cfg.RendererURL)
+	siteDomain := cfg.SiteDomain
 
 	r.StrictSlash(true).Path("/health").HandlerFunc(hc.Handler)
 
-	r.StrictSlash(true).Path("/cookies/accept-all").Methods("GET").HandlerFunc(handlers.AcceptAll(*cfg))
+	r.StrictSlash(true).Path("/cookies/accept-all").Methods("GET").HandlerFunc(handlers.AcceptAll(siteDomain))
 	r.StrictSlash(true).Path("/cookies").Methods("GET").HandlerFunc(handlers.Read(rendC))
-	r.StrictSlash(true).Path("/cookies").Methods("POST").HandlerFunc(handlers.Edit(rendC, *cfg))
+	r.StrictSlash(true).Path("/cookies").Methods("POST").HandlerFunc(handlers.Edit(rendC, siteDomain))
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -20,7 +20,7 @@ func Init(ctx context.Context, r *mux.Router, cfg *config.Config, hc health.Heal
 
 	r.StrictSlash(true).Path("/health").HandlerFunc(hc.Handler)
 
-	r.StrictSlash(true).Path("/cookies/accept-all").Methods("GET").HandlerFunc(handlers.AcceptAll())
+	r.StrictSlash(true).Path("/cookies/accept-all").Methods("GET").HandlerFunc(handlers.AcceptAll(*cfg))
 	r.StrictSlash(true).Path("/cookies").Methods("GET").HandlerFunc(handlers.Read(rendC))
-	r.StrictSlash(true).Path("/cookies").Methods("POST").HandlerFunc(handlers.Edit(rendC))
+	r.StrictSlash(true).Path("/cookies").Methods("POST").HandlerFunc(handlers.Edit(rendC, *cfg))
 }


### PR DESCRIPTION
### What

Previously domain wasn't actually being set on cookies
- Domain should contain a prefix of a '.' to show that the cookie is available to subdomains
- Domain should not contain any subdomains, or this will limit the cookie to being read by only that domain
- These changes mean that the user if setting cookies on Welsh or English won't be asked again or have a different configuration when changing over to a different language
### How to review

Check that the domain is correctly set e.g. "ons.go.uk"

### Who can review

Anyone except me
