### PR TITLE
Feature/cookies preferences success msg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.2.0
 	github.com/ONSdigital/dp-cookies v0.0.0-20200214134455-04af19eb3925
-	github.com/ONSdigital/dp-frontend-models v1.3.0
+	github.com/ONSdigital/dp-frontend-models v1.4.0
 	github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
 	github.com/ONSdigital/log.go v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.2.0
 	github.com/ONSdigital/dp-cookies v0.0.0-20200214134455-04af19eb3925
-	github.com/ONSdigital/dp-frontend-models v1.4.0
+	github.com/ONSdigital/dp-frontend-models v1.4.1
 	github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
 	github.com/ONSdigital/log.go v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/ONSdigital/dp-frontend-models v1.2.0 h1:HqlXJbnzsLkN31nYQ+gU11N7K1ppx
 github.com/ONSdigital/dp-frontend-models v1.2.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
 github.com/ONSdigital/dp-frontend-models v1.3.0 h1:CHOLW44yHlJhBci0/9etRE/Q091O0/9zjWZkfdQb0Bs=
 github.com/ONSdigital/dp-frontend-models v1.3.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
+github.com/ONSdigital/dp-frontend-models v1.4.0 h1:TUxB9w+Uk7FL+h+FZwVQFnE611MhwItctinqoSS7lmo=
+github.com/ONSdigital/dp-frontend-models v1.4.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e h1:H2KVzsFp5oTbqjPXDlTHOB/LvYy2I6Mc8eSTLrmZkXs=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/ONSdigital/dp-frontend-models v1.3.0 h1:CHOLW44yHlJhBci0/9etRE/Q091O0
 github.com/ONSdigital/dp-frontend-models v1.3.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
 github.com/ONSdigital/dp-frontend-models v1.4.0 h1:TUxB9w+Uk7FL+h+FZwVQFnE611MhwItctinqoSS7lmo=
 github.com/ONSdigital/dp-frontend-models v1.4.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
+github.com/ONSdigital/dp-frontend-models v1.4.1 h1:zaBwBe1Z15iRnPCrYd7FNWfJb7Vq0k/toIwozlHuAaQ=
+github.com/ONSdigital/dp-frontend-models v1.4.1/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e h1:H2KVzsFp5oTbqjPXDlTHOB/LvYy2I6Mc8eSTLrmZkXs=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -105,35 +105,6 @@ func Edit(rendC RenderClient, siteDomain string) http.HandlerFunc {
 	}
 }
 
-<<<<<<< HEAD
-// acceptAll handler for accepting all possible cookies
-func acceptAll(w http.ResponseWriter, req *http.Request) {
-	ctx := req.Context()
-	cp := cookies.Policy{
-		Essential: true,
-		Usage:     true,
-	}
-	reqUrl, err := url.Parse(req.URL.Path)
-	if err != nil {
-		log.Event(ctx, "unable to parse url", log.Error(err))
-		setStatusCode(req, w, err)
-		return
-	}
-	cookies.SetPolicy(w, cp, reqUrl.Hostname())
-	cookies.SetPreferenceIsSet(w, reqUrl.Hostname())
-	referer := req.Header.Get("Referer")
-	if referer == "" {
-		err := errors.New("cannot redirect due to no referer header")
-		log.Event(ctx, "unable to parse url", log.Error(err))
-		setStatusCode(req, w, err)
-		return
-	}
-	log.Event(ctx, "redirecting to "+referer, log.INFO)
-	http.Redirect(w, req, referer, http.StatusFound)
-}
-
-=======
->>>>>>> develop
 // edit handler for changing and setting cookie preferences, returns populated cookie preferences page from the renderer
 func edit(w http.ResponseWriter, req *http.Request, rendC RenderClient, siteDomain string) {
 	ctx := req.Context()
@@ -162,16 +133,10 @@ func edit(w http.ResponseWriter, req *http.Request, rendC RenderClient, siteDoma
 	if !usage {
 		removeNonProtectedCookies(w, req)
 	}
-<<<<<<< HEAD
-	cookies.SetPreferenceIsSet(w, reqUrl.Hostname())
-	cookies.SetPolicy(w, cp, reqUrl.Hostname())
-	isUpdated := true
-	err = getCookiePreferencePage(w, req, rendC, cp, isUpdated)
-=======
 	cookies.SetPreferenceIsSet(w, siteDomain)
 	cookies.SetPolicy(w, cp, siteDomain)
-	err = getCookiePreferencePage(w, req, rendC, cp)
->>>>>>> develop
+	isUpdated := true
+	err = getCookiePreferencePage(w, req, rendC, cp, isUpdated)
 	if err != nil {
 		log.Event(ctx, "getting cookie preference page failed", log.Error(err))
 	}

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -3,7 +3,7 @@ package mapper
 import (
 	"github.com/ONSdigital/dp-cookies/cookies"
 	"github.com/ONSdigital/dp-frontend-models/model"
-	cookiespreferences "github.com/ONSdigital/dp-frontend-models/model/cookiesPreferences"
+	"github.com/ONSdigital/dp-frontend-models/model/cookiespreferences"
 )
 
 // CreateCookieSettingPage maps type cookies.Policy to model.Page

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -3,11 +3,12 @@ package mapper
 import (
 	"github.com/ONSdigital/dp-cookies/cookies"
 	"github.com/ONSdigital/dp-frontend-models/model"
+	cookiespreferences "github.com/ONSdigital/dp-frontend-models/model/cookiesPreferences"
 )
 
 // CreateCookieSettingPage maps type cookies.Policy to model.Page
-func CreateCookieSettingPage(policy cookies.Policy) model.Page {
-	var page model.Page
+func CreateCookieSettingPage(policy cookies.Policy, isUpdated bool) cookiespreferences.Page {
+	var page cookiespreferences.Page
 	page.Breadcrumb = []model.TaxonomyNode{
 		{
 			Title: "Home",
@@ -21,5 +22,9 @@ func CreateCookieSettingPage(policy cookies.Policy) model.Page {
 	page.CookiesPreferencesSet = true
 	page.CookiesPolicy.Essential = policy.Essential
 	page.CookiesPolicy.Usage = policy.Usage
+
+	// Determine whether or not to show success message. Currently this will be shown when cookies preferences have been updated by the user.
+	page.PreferencesUpdated = isUpdated
+
 	return page
 }

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -2,12 +2,11 @@ package mapper
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/ONSdigital/dp-cookies/cookies"
 	"github.com/ONSdigital/dp-frontend-models/model"
-
-	"testing"
-
+	"github.com/ONSdigital/dp-frontend-models/model/cookiespreferences"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -18,27 +17,23 @@ func TestUnitMapper(t *testing.T) {
 		Essential: true,
 		Usage:     false,
 	}
-	expectedModel := model.Page{
-		Breadcrumb: []model.TaxonomyNode{
-			{
-				Title: "Home",
-				URI:   "/",
-			},
-			{
-				Title: "Cookies",
-			},
+	expectedModel := cookiespreferences.Page{}
+	expectedModel.Breadcrumb = []model.TaxonomyNode{
+		{
+			Title: "Home",
+			URI:   "/",
 		},
-		CookiesPolicy: model.CookiesPolicy{
-			Essential: true,
-			Usage:     false,
-		},
-		CookiesPreferencesSet: true,
-		Metadata: model.Metadata{
+		{
 			Title: "Cookies",
 		},
 	}
+	expectedModel.Metadata.Title = "Cookies"
+	expectedModel.CookiesPreferencesSet = true
+	expectedModel.CookiesPolicy.Essential = true
+	expectedModel.CookiesPolicy.Usage = false
+	expectedModel.PreferencesUpdated = false
 	Convey("test CreateCookieSettingPage", t, func() {
-		mcp := CreateCookieSettingPage(cookiesPolicy)
+		mcp := CreateCookieSettingPage(cookiesPolicy, false)
 		fmt.Printf("%+v\n", mcp)
 		So(expectedModel, ShouldResemble, mcp)
 	})


### PR DESCRIPTION
### What

- Updated `getCookiePreferencePage` and `createCookiePreferencePage` functions to accept an additional argument, `isUpdated`, to determine whether or not the cookies preference success message should be displayed. This allows us to display the message when these two functions are called via `edit`, but not via any other instance where the preferences page is created
- Updated `dp-frontend-models` version to allow us to use the `cookiespreferences` page model which includes the `PreferencesUpdated` boolean

### How to review

- Ensure the cookies preference success message only appears after cookies have been updated via the form

### Who can review

Anyone but me
