### PR TITLE
Accept all end point removed and fix for non protected cookies not being deleted

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -82,7 +82,7 @@ func removeNonProtectedCookies(w http.ResponseWriter, req *http.Request) {
 				Value:    "",
 				Path:     "/",
 				Expires:  time.Unix(0, 0),
-				//MaxAge:   0,
+				MaxAge:   0,
 				HttpOnly: false,
 			}
 			http.SetCookie(w, cookie)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -82,18 +82,11 @@ func removeNonProtectedCookies(w http.ResponseWriter, req *http.Request) {
 				Value:    "",
 				Path:     "/",
 				Expires:  time.Unix(0, 0),
+				//MaxAge:   0,
 				HttpOnly: false,
 			}
 			http.SetCookie(w, cookie)
 		}
-	}
-}
-
-// AcceptAll handler for setting all cookies to enabled then refresh the page. when JS has been disabled
-// Example usage; JavaScript disabled.
-func AcceptAll(siteDomain string) http.HandlerFunc {
-	return func(w http.ResponseWriter, req *http.Request) {
-		acceptAll(w, req, siteDomain)
 	}
 }
 
@@ -109,31 +102,6 @@ func Edit(rendC RenderClient, siteDomain string) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		edit(w, req, rendC, siteDomain)
 	}
-}
-
-// acceptAll handler for accepting all possible cookies
-func acceptAll(w http.ResponseWriter, req *http.Request, siteDomain string) {
-	log.Event(nil, "acceptAll hit")
-	ctx := req.Context()
-	cp := cookies.Policy{
-		Essential: true,
-		Usage:     true,
-	}
-	log.Event(nil, "set policy")
-	cookies.SetPolicy(w, cp, siteDomain)
-	log.Event(nil, "set preferences")
-	cookies.SetPreferenceIsSet(w, siteDomain)
-
-	referer := req.Header.Get("Referer")
-	log.Event(nil, "got referer")
-	if referer == "" {
-		err := errors.New("cannot redirect due to no referer header")
-		log.Event(ctx, "unable to parse url", log.Error(err))
-		setStatusCode(req, w, err)
-		return
-	}
-	log.Event(nil, "now redirect")
-	http.Redirect(w, req, referer, http.StatusFound)
 }
 
 // edit handler for changing and setting cookie preferences, returns populated cookie preferences page from the renderer

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -105,40 +105,6 @@ func TestUnitHandlers(t *testing.T) {
 			So(w.Code, ShouldEqual, http.StatusNotFound)
 		})
 
-		Convey("test status code handles internal server error", func() {
-			req := httptest.NewRequest("GET", "/cookies/accept-all", nil)
-			w := httptest.NewRecorder()
-			err := errors.New("internal server error")
-			setStatusCode(req, w, err)
-
-			So(w.Code, ShouldEqual, http.StatusInternalServerError)
-		})
-	})
-
-	Convey("test acceptAll", t, func() {
-
-		Convey("is success", func() {
-			cookiesPol := cookies.Policy{
-				Essential: true,
-				Usage:     true,
-			}
-			referer := "https://www.ons.gov.uk"
-			req := httptest.NewRequest("GET", "/cookies/accept-all", nil)
-			req.Header.Set("Referer", referer)
-			w := doTestRequest("/cookies/accept-all", req, AcceptAll(cfg.SiteDomain), nil)
-
-			So(w.Header().Get("Location"), ShouldEqual, referer)
-			So(w.Code, ShouldEqual, http.StatusFound)
-			cookiePolicyTest(w, cookiesPol)
-			// TODO once library update check cookies have been set
-		})
-
-		Convey("is failure no referer header", func() {
-			req := httptest.NewRequest("GET", "/cookies/accept-all", nil)
-			w := doTestRequest("/cookies/accept-all", req, AcceptAll(cfg.SiteDomain), nil)
-
-			So(w.Code, ShouldEqual, http.StatusInternalServerError)
-		})
 	})
 
 	Convey("test read", t, func() {

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -21,7 +21,6 @@ func Init(ctx context.Context, r *mux.Router, cfg *config.Config, hc health.Heal
 
 	r.StrictSlash(true).Path("/health").HandlerFunc(hc.Handler)
 
-	r.StrictSlash(true).Path("/cookies/accept-all").Methods("GET").HandlerFunc(handlers.AcceptAll(siteDomain))
 	r.StrictSlash(true).Path("/cookies").Methods("GET").HandlerFunc(handlers.Read(rendC))
 	r.StrictSlash(true).Path("/cookies").Methods("POST").HandlerFunc(handlers.Edit(rendC, siteDomain))
 }


### PR DESCRIPTION
### What

- Accept all end point given the axe as it is no longer needed
- Fix for non protected cookies not being deleted ( max age added )

### How to review

Check every reference to the accept all end point has been removed
Check that if you set a cookie and then go to cookie preferences and select no usage cookies that the cookie is removed (note GA ones will reappear atm due to GTM work)

### Who can review

Anyone except me