### PR TITLE
update Dockerfile.concourse to use ubuntu22.04 image

### DIFF
--- a/Dockerfile.concourse
+++ b/Dockerfile.concourse
@@ -1,4 +1,4 @@
-FROM onsdigital/dp-concourse-tools-ubuntu-20:ubuntu20.4-rc.1
+FROM onsdigital/dp-concourse-tools-ubuntu-22:ubuntu22.4-jammy-20250126
 
 WORKDIR /app/
 


### PR DESCRIPTION
### What

As per title

### How to review

Check updated image name with whats in CI elastic container registry.

### Who can review

Linden
