### PR TITLE
Feature/convert form to match design system pattern

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,20 +1,20 @@
 # This file was inspired by the golangci-lint one:
 # https://github.com/golangci/golangci-lint/blob/master/.golangci.yml
 run:
-  # default concurrency is a available CPU number
+  # number of operating system threads that can execute golangci-lint simultaneously
   concurrency: 4
 
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 5m
 linters-settings:
   govet:
-    check-shadowing: true
+    shadow: true
   golint:
     min-confidence: 0
   gocyclo:
     min-complexity: 20
   gocognit:
-    min-complexity: 100
+    min-complexity: 40
   maligned:
     suggest-new: true
   dupl:
@@ -41,6 +41,14 @@ linters-settings:
       - ifElseChain
       - octalLiteral
       - hugeParam
+  revive:
+    rules:
+      # disabled as parameter names are useful for context even when unused, especially in interface implementations
+      - name: unused-parameter
+        severity: warning
+        disabled: true
+    include:
+      - "**/*_test.go" # Specify test files to include
   funlen:
   # lines: 100
   # statements: 100
@@ -50,8 +58,8 @@ linters:
   # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
   disable-all: true
   enable:
-    - deadcode
     - dogsled
+    - errcheck
     - gochecknoinits
     - goconst
     - gocritic
@@ -60,11 +68,15 @@ linters:
     - goimports
     - revive
     - gosec
+    - gosimple
     - govet
     - ineffassign
     - nakedret
+    - staticcheck
+    - stylecheck
+    - typecheck
     - unconvert
-    - varcheck
+    - unused
     - whitespace
     - gocognit
     - prealloc
@@ -77,20 +89,10 @@ issues:
         - errcheck
         - dupl
         - gosec
-        - goconst
-        - revive
-        - gocritic
-        - ineffassign
-        - govet
-        - typecheck
-    - path: main.go
+    # Allow dot import in test files for goconvey
+    - path: _test.go
+      text: "dot-imports"
       linters:
-        - typecheck
+        - revive
+      source: "github.com/smartystreets/goconvey/convey"
   new: false
-
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.53.x # use the fixed version to not introduce new linters unexpectedly
-  prepare:
-    - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ audit:
 build: generate-prod
 	go build -tags 'production' -o $(BINPATH)/dp-frontend-cookie-controller -ldflags "-X main.BuildTime=$(BUILD_TIME) -X main.GitCommit=$(GIT_COMMIT) -X main.Version=$(VERSION)"
 
-lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3
-	golangci-lint run ./...
+.PHONY: lint
+lint: generate-prod
+	golangci-lint run ./... --build-tags 'production'
 
 .PHONY: debug
 debug: generate-debug

--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -36,8 +36,8 @@ description = "Cookie settings"
 one = "Cookie settings"
 
 [CookiesNoJSWarn1]
-description = "We use JavaScript to set our cookies. Javascript is not running on your browser so you cannot change your settings."
-one = "We use JavaScript to set our cookies. Javascript is not running on your browser so you cannot change your settings."
+description = "We use JavaScript to set our cookies. JavaScript is not running on your browser so you cannot change your settings."
+one = "We use JavaScript to set our cookies. JavaScript is not running on your browser so you cannot change your settings."
 
 [CookiesNoJSWarn2]
 description = "You can try:"
@@ -92,8 +92,8 @@ description = "Cookies that help with our communications"
 one = "Cookies that help with our communications"
 
 [CookiesCommsP1]
-description = "Some of our pages may contain content from other sites, like YouTube, which may set their own cookies. These sites are sometimes called “third party” services. This tells us how many people are seeing the content and whether it’s useful."
-one = "Some of our pages may contain content from other sites, like YouTube, which may set their own cookies. These sites are sometimes called “third party” services. This tells us how many people are seeing the content and whether it’s useful."
+description = "Some of our pages may contain content from other sites, like YouTube, which may set their own cookies. These sites are sometimes called \"third party\" services. This tells us how many people are seeing the content and whether it’s useful."
+one = "Some of our pages may contain content from other sites, like YouTube, which may set their own cookies. These sites are sometimes called \"third party\" services. This tells us how many people are seeing the content and whether it’s useful."
 
 [CookiesCommsP2]
 description = "In addition, if you share a link to a ons.gov.uk page, the service you share it on may set a cookie. We have no control over cookies set on other websites – you can turn them off, but not through us."
@@ -128,8 +128,8 @@ description = "remember the notifications you've seen so we do not show them to 
 one = "remember the notifications you've seen so we do not show them to you again"
 
 [CookiesEssentialBP2]
-description = "remember your progress through a form (for example, an ons study)"
-one = "remember your progress through a form (for example, an ons study)"
+description = "remember your progress through a form (for example, an ONS study)"
+one = "remember your progress through a form (for example, an ONS study)"
 
 [CookiesEssentialP2]
 description = "They always need to be on."
@@ -138,6 +138,10 @@ one = "They always need to be on."
 [CookiesEssentialP3]
 description = "Learn more about cookies on ons.gov.uk"
 one = "<a href=\"/help/cookies\">Learn more about cookies on ons.gov.uk</a>"
+
+[CookiesPreferencesCompleted]
+description = "Completed"
+one = "Completed"
 
 [CookiesPreferencesSaved]
 description = "Your cookie settings have been saved"

--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -20,40 +20,40 @@
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 [CookiesOnONS]
-description = "Cookies on ONS.GOV.UK"
-one = "Cookies on ONS.GOV.UK"
+description = "Cookies on ons.gov.uk"
+one = "Cookies on ons.gov.uk"
 
 [CookiesP1]
-description = "Cookies are files saved on your phone, tablet or computer when you visit a website."
-one = "Cookies are files saved on your phone, tablet or computer when you visit a website."
+description = "Cookies are small files saved on your phone, tablet or computer when you visit a website."
+one = "Cookies are small files saved on your phone, tablet or computer when you visit a website."
 
 [CookiesP2]
-description = "We use cookies to store information about how you use the ons.gov.uk website, such as the pages you visit."
-one = "We use cookies to store information about how you use the ons.gov.uk website, such as the pages you visit."
+description = "We use cookies to store information about how you use the ONS website, such as the pages you visit."
+one = "We use cookies to store information about how you use the ONS website, such as the pages you visit."
 
 [CookiesSettings]
 description = "Cookie settings"
 one = "Cookie settings"
 
 [CookiesNoJSWarn1]
-description = "We use JavaScript to set most of our cookies. It appears that JavaScript is not running on your browser, so we are unable to change your cookie settings. To change this you can try:"
-one = "We use JavaScript to set most of our cookies. It appears that JavaScript is not running on your browser, so we are unable to change your cookie settings. To change this you can try:"
+description = "We use JavaScript to set our cookies. Javascript is not running on your browser so you cannot change your settings."
+one = "We use JavaScript to set our cookies. Javascript is not running on your browser so you cannot change your settings."
 
 [CookiesNoJSWarn2]
-description = "Without JavaScript we will only set cookies that are strictly necessary."
-one = "Without JavaScript we will only set cookies that are strictly necessary."
+description = "You can try:"
+one = "You can try:"
 
 [CookiesNoJSOpt1]
-description = "reloading the page"
-one = "reloading the page"
-
-[CookiesNoJSOpt2]
 description = "turning on JavaScript in your browser"
 one = "turning on JavaScript in your browser"
 
+[CookiesNoJSOpt2]
+description = "reloading the page in case there was a temporary fault with JavaScript"
+one = "reloading the page in case there was a temporary fault with JavaScript"
+
 [CookiesSettingsP1]
-description = "We use 2 types of cookie. You can choose which cookies you're happy for us to use."
-one = "We use 2 types of cookie. You can choose which cookies you're happy for us to use."
+description = "We use three types of cookie. You can choose which cookies you're happy for us to use."
+one = "We use three types of cookie. You can choose which cookies you're happy for us to use."
 
 [CookiesUsage]
 description = "Cookies that measure website use"
@@ -72,8 +72,8 @@ description = "the pages you visit on ons.gov.uk and how long you spend on each 
 one = "the pages you visit on ons.gov.uk and how long you spend on each page"
 
 [CookiesUsageBP3]
-description = "what you click on while you are visiting the site"
-one = "what you click on while you are visiting the site"
+description = "what you click on while you're visiting the site"
+one = "what you click on while you're visiting the site"
 
 [CookiesUsageBP4]
 description = "the way in which you interact with a page"
@@ -87,28 +87,64 @@ one = "whether you have participated in a Hotjar survey"
 description = "Regardless of your choice, we do not allow Google or Hotjar to use or share the data about how you use this site."
 one = "Regardless of your choice, we do not allow Google or Hotjar to use or share the data about how you use this site."
 
+[CookiesComms]
+description = "Cookies that help with our communications"
+one = "Cookies that help with our communications"
+
+[CookiesCommsP1]
+description = "Some of our pages may contain content from other sites, like YouTube, which may set their own cookies. These sites are sometimes called “third party” services. This tells us how many people are seeing the content and whether it’s useful."
+one = "Some of our pages may contain content from other sites, like YouTube, which may set their own cookies. These sites are sometimes called “third party” services. This tells us how many people are seeing the content and whether it’s useful."
+
+[CookiesCommsP2]
+description = "In addition, if you share a link to a ons.gov.uk page, the service you share it on may set a cookie. We have no control over cookies set on other websites – you can turn them off, but not through us."
+one = "In addition, if you share a link to a ons.gov.uk page, the service you share it on may set a cookie. We have no control over cookies set on other websites – you can turn them off, but not through us."
+
+[CookiesCommsSubHead1]
+description = "YouTube videos"
+one = "YouTube videos"
+
+[CookiesCommsSubP1]
+description = "We use YouTube to show videos on some ons.gov.uk pages. YouTube sets cookies when you visit one of these pages."
+one = "We use YouTube to show videos on some ons.gov.uk pages. YouTube sets cookies when you visit one of these pages."
+
+[CookiesSiteSettings]
+description = "Cookies that remember your settings"
+one = "Cookies that remember your settings"
+
+[CookiesSiteSettingsP1]
+description = "These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site."
+one = "These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site."
+
 [CookiesEssential]
 description = "Strictly necessary cookies"
 one = "Strictly necessary cookies"
 
 [CookiesEssentialP1]
-description = "These essential cookies do things like remember your progress through a form."
-one = "These essential cookies do things like remember your progress through a form."
+description = "These essential cookies do things like:"
+one = "These essential cookies do things like:"
+
+[CookiesEssentialBP1]
+description = "remember the notifications you've seen so we do not show them to you again"
+one = "remember the notifications you've seen so we do not show them to you again"
+
+[CookiesEssentialBP2]
+description = "remember your progress through a form (for example, an ons study)"
+one = "remember your progress through a form (for example, an ons study)"
 
 [CookiesEssentialP2]
-description = "They always need to be on to allow the website to function properly."
-one = "They always need to be on to allow the website to function properly."
+description = "They always need to be on."
+one = "They always need to be on."
 
 [CookiesEssentialP3]
-description = "Find out more about cookies on ons.gov.uk"
-one = "<a href=\"/help/cookies\">Find out more about cookies on ons.gov.uk</a>"
+description = "Learn more about cookies on ons.gov.uk"
+one = "<a href=\"/help/cookies\">Learn more about cookies on ons.gov.uk</a>"
 
 [CookiesPreferencesSaved]
-description = "We have saved your cookie preferences."
-one = "We have saved your cookie preference."
-other = "We have saved your cookie preferences."
+description = "Your cookie settings have been saved"
+one = "Your cookie setting has been saved"
+other = "Your cookie settings have been saved"
 
 [CookiesPreferencesSavedAmend]
-description = "Should you ever wish to amend them, visit <strong><a href=\"/cookies\">ons.gov.uk/cookies</a></strong>."
-one = "Should you ever wish to amend them, visit <strong><a href=\"/cookies\">ons.gov.uk/cookies</a></strong>."
-other = "Should you ever wish to amend them, visit <strong><a href=\"/cookies\">ons.gov.uk/cookies</a></strong>."
+description = "Some parts of the ONS may use additional cookies and will have their own cookie policy and banner."
+one = "Some parts of the ONS may use an additional cookie and will have their own cookie policy and banner."
+other = "Some parts of the ONS may use additional cookies and will have their own cookie policy and banner."

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -36,8 +36,8 @@ description = "Cookie settings"
 one = "Cookie settings"
 
 [CookiesNoJSWarn1]
-description = "We use JavaScript to set our cookies. Javascript is not running on your browser so you cannot change your settings."
-one = "We use JavaScript to set our cookies. Javascript is not running on your browser so you cannot change your settings."
+description = "We use JavaScript to set our cookies. JavaScript is not running on your browser so you cannot change your settings."
+one = "We use JavaScript to set our cookies. JavaScript is not running on your browser so you cannot change your settings."
 
 [CookiesNoJSWarn2]
 description = "You can try:"
@@ -92,8 +92,8 @@ description = "Cookies that help with our communications"
 one = "Cookies that help with our communications"
 
 [CookiesCommsP1]
-description = "Some of our pages may contain content from other sites, like YouTube, which may set their own cookies. These sites are sometimes called “third party” services. This tells us how many people are seeing the content and whether it’s useful."
-one = "Some of our pages may contain content from other sites, like YouTube, which may set their own cookies. These sites are sometimes called “third party” services. This tells us how many people are seeing the content and whether it’s useful."
+description = "Some of our pages may contain content from other sites, like YouTube, which may set their own cookies. These sites are sometimes called \"third party\" services. This tells us how many people are seeing the content and whether it’s useful."
+one = "Some of our pages may contain content from other sites, like YouTube, which may set their own cookies. These sites are sometimes called \"third party\" services. This tells us how many people are seeing the content and whether it’s useful."
 
 [CookiesCommsP2]
 description = "In addition, if you share a link to a ons.gov.uk page, the service you share it on may set a cookie. We have no control over cookies set on other websites – you can turn them off, but not through us."
@@ -128,8 +128,8 @@ description = "remember the notifications you've seen so we do not show them to 
 one = "remember the notifications you've seen so we do not show them to you again"
 
 [CookiesEssentialBP2]
-description = "remember your progress through a form (for example, an ons study)"
-one = "remember your progress through a form (for example, an ons study)"
+description = "remember your progress through a form (for example, an ONS study)"
+one = "remember your progress through a form (for example, an ONS study)"
 
 [CookiesEssentialP2]
 description = "They always need to be on."
@@ -138,6 +138,10 @@ one = "They always need to be on."
 [CookiesEssentialP3]
 description = "Learn more about cookies on ons.gov.uk"
 one = "<a href=\"/help/cookies\">Learn more about cookies on ons.gov.uk</a>"
+
+[CookiesPreferencesCompleted]
+description = "Completed"
+one = "Completed"
 
 [CookiesPreferencesSaved]
 description = "Your cookie settings have been saved"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -20,40 +20,40 @@
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 [CookiesOnONS]
-description = "Cookies on ONS.GOV.UK"
-one = "Cookies on ONS.GOV.UK"
+description = "Cookies on ons.gov.uk"
+one = "Cookies on ons.gov.uk"
 
 [CookiesP1]
-description = "Cookies are files saved on your phone, tablet or computer when you visit a website."
-one = "Cookies are files saved on your phone, tablet or computer when you visit a website."
+description = "Cookies are small files saved on your phone, tablet or computer when you visit a website."
+one = "Cookies are small files saved on your phone, tablet or computer when you visit a website."
 
 [CookiesP2]
-description = "We use cookies to store information about how you use the ons.gov.uk website, such as the pages you visit."
-one = "We use cookies to store information about how you use the ons.gov.uk website, such as the pages you visit."
+description = "We use cookies to store information about how you use the ONS website, such as the pages you visit."
+one = "We use cookies to store information about how you use the ONS website, such as the pages you visit."
 
 [CookiesSettings]
 description = "Cookie settings"
 one = "Cookie settings"
 
 [CookiesNoJSWarn1]
-description = "We use JavaScript to set most of our cookies. It appears that JavaScript is not running on your browser, so we are unable to change your cookie settings. To change this you can try:"
-one = "We use JavaScript to set most of our cookies. It appears that JavaScript is not running on your browser, so we are unable to change your cookie settings. To change this you can try:"
+description = "We use JavaScript to set our cookies. Javascript is not running on your browser so you cannot change your settings."
+one = "We use JavaScript to set our cookies. Javascript is not running on your browser so you cannot change your settings."
 
 [CookiesNoJSWarn2]
-description = "Without JavaScript we will only set cookies that are strictly necessary."
-one = "Without JavaScript we will only set cookies that are strictly necessary."
+description = "You can try:"
+one = "You can try:"
 
 [CookiesNoJSOpt1]
-description = "reloading the page"
-one = "reloading the page"
-
-[CookiesNoJSOpt2]
 description = "turning on JavaScript in your browser"
 one = "turning on JavaScript in your browser"
 
+[CookiesNoJSOpt2]
+description = "reloading the page in case there was a temporary fault with JavaScript"
+one = "reloading the page in case there was a temporary fault with JavaScript"
+
 [CookiesSettingsP1]
-description = "We use 2 types of cookie. You can choose which cookies you're happy for us to use."
-one = "We use 2 types of cookie. You can choose which cookies you're happy for us to use."
+description = "We use three types of cookie. You can choose which cookies you're happy for us to use."
+one = "We use three types of cookie. You can choose which cookies you're happy for us to use."
 
 [CookiesUsage]
 description = "Cookies that measure website use"
@@ -72,8 +72,8 @@ description = "the pages you visit on ons.gov.uk and how long you spend on each 
 one = "the pages you visit on ons.gov.uk and how long you spend on each page"
 
 [CookiesUsageBP3]
-description = "what you click on while you are visiting the site"
-one = "what you click on while you are visiting the site"
+description = "what you click on while you're visiting the site"
+one = "what you click on while you're visiting the site"
 
 [CookiesUsageBP4]
 description = "the way in which you interact with a page"
@@ -87,28 +87,64 @@ one = "whether you have participated in a Hotjar survey"
 description = "Regardless of your choice, we do not allow Google or Hotjar to use or share the data about how you use this site."
 one = "Regardless of your choice, we do not allow Google or Hotjar to use or share the data about how you use this site."
 
+[CookiesComms]
+description = "Cookies that help with our communications"
+one = "Cookies that help with our communications"
+
+[CookiesCommsP1]
+description = "Some of our pages may contain content from other sites, like YouTube, which may set their own cookies. These sites are sometimes called “third party” services. This tells us how many people are seeing the content and whether it’s useful."
+one = "Some of our pages may contain content from other sites, like YouTube, which may set their own cookies. These sites are sometimes called “third party” services. This tells us how many people are seeing the content and whether it’s useful."
+
+[CookiesCommsP2]
+description = "In addition, if you share a link to a ons.gov.uk page, the service you share it on may set a cookie. We have no control over cookies set on other websites – you can turn them off, but not through us."
+one = "In addition, if you share a link to a ons.gov.uk page, the service you share it on may set a cookie. We have no control over cookies set on other websites – you can turn them off, but not through us."
+
+[CookiesCommsSubHead1]
+description = "YouTube videos"
+one = "YouTube videos"
+
+[CookiesCommsSubP1]
+description = "We use YouTube to show videos on some ons.gov.uk pages. YouTube sets cookies when you visit one of these pages."
+one = "We use YouTube to show videos on some ons.gov.uk pages. YouTube sets cookies when you visit one of these pages."
+
+[CookiesSiteSettings]
+description = "Cookies that remember your settings"
+one = "Cookies that remember your settings"
+
+[CookiesSiteSettingsP1]
+description = "These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site."
+one = "These cookies do things like remember your preferences and the choices you make, to personalise your experience of using the site."
+
 [CookiesEssential]
 description = "Strictly necessary cookies"
 one = "Strictly necessary cookies"
 
 [CookiesEssentialP1]
-description = "These essential cookies do things like remember your progress through a form."
-one = "These essential cookies do things like remember your progress through a form."
+description = "These essential cookies do things like:"
+one = "These essential cookies do things like:"
+
+[CookiesEssentialBP1]
+description = "remember the notifications you've seen so we do not show them to you again"
+one = "remember the notifications you've seen so we do not show them to you again"
+
+[CookiesEssentialBP2]
+description = "remember your progress through a form (for example, an ons study)"
+one = "remember your progress through a form (for example, an ons study)"
 
 [CookiesEssentialP2]
-description = "They always need to be on to allow the website to function properly."
-one = "They always need to be on to allow the website to function properly."
+description = "They always need to be on."
+one = "They always need to be on."
 
 [CookiesEssentialP3]
-description = "Find out more about cookies on ons.gov.uk"
-one = "<a href=\"/help/cookies\">Find out more about cookies on ons.gov.uk</a>"
+description = "Learn more about cookies on ons.gov.uk"
+one = "<a href=\"/help/cookies\">Learn more about cookies on ons.gov.uk</a>"
 
 [CookiesPreferencesSaved]
-description = "We have saved your cookie preferences."
-one = "We have saved your cookie preference."
-other = "We have saved your cookie preferences."
+description = "Your cookie settings have been saved"
+one = "Your cookie setting has been saved"
+other = "Your cookie settings have been saved"
 
 [CookiesPreferencesSavedAmend]
-description = "Should you ever wish to amend them, visit <strong><a href=\"/cookies\">ons.gov.uk/cookies</a></strong>."
-one = "Should you ever wish to amend them, visit <strong><a href=\"/cookies\">ons.gov.uk/cookies</a></strong>."
-other = "Should you ever wish to amend them, visit <strong><a href=\"/cookies\">ons.gov.uk/cookies</a></strong>."
+description = "Some parts of the ONS may use additional cookies and will have their own cookie policy and banner."
+one = "Some parts of the ONS may use an additional cookie and will have their own cookie policy and banner."
+other = "Some parts of the ONS may use additional cookies and will have their own cookie policy and banner."

--- a/assets/templates/cookies-preferences.tmpl
+++ b/assets/templates/cookies-preferences.tmpl
@@ -4,59 +4,86 @@
             <h1 class="ons-u-fs-xxxl ons-u-mt-m ons-u-fw-b"> {{- localise "CookiesOnONS" .Language 1 -}} </h1>
             <div class="ons-page__main ons-u-mt-no">
                 {{if .PreferencesUpdated }}
-                    <div aria-labelledby="alert" role="alert" tabindex="-1" class="ons-panel ons-panel--success ons-panel--no-title ons-u-mb-s" id="success-id">
-                        <span id="alert" class="ons-panel__assistive-text ons-u-vh">Completed: </span>
-                        <div class="ons-panel__body">
-                            <h2>{{- localise "CookiesPreferencesSaved" .Language 4 -}}</h2>
-                            <p>{{- localise "CookiesPreferencesSavedAmend" .Language 4 | safeHTML -}}</p>
-                        </div>
+                <div
+                    aria-labelledby="alert"
+                    role="alert"
+                    tabindex="-1"
+                    class="ons-panel ons-panel--success ons-panel--no-title ons-u-mb-l"
+                    id="success-id"
+                >
+                    <span
+                        id="alert"
+                        class="ons-panel__assistive-text ons-u-vh"
+                    >Completed: </span>
+                    <div class="ons-panel__body">
+                        <h2>{{- localise "CookiesPreferencesSaved" .Language 4 -}}</h2>
+                        <p>{{- localise "CookiesPreferencesSavedAmend" .Language 4 | safeHTML -}}</p>
                     </div>
+                </div>
                 {{end}}
 
                 <p>{{- localise "CookiesP1" .Language 1 -}}</p>
                 <p>{{- localise "CookiesP2" .Language 1 -}}</p>
 
-                <h2>{{- localise "CookiesSettings" .Language 1 -}}</h2>
+                <h2 class="ons-u-mt-l">{{- localise "CookiesSettings" .Language 1 -}}</h2>
 
                 <p class="cookies-js hidden">{{- localise "CookiesSettingsP1" .Language 1 -}}</p>
 
                 <div class="cookies-no-js">
                     <p> {{- localise "CookiesNoJSWarn1" .Language 1 -}} </p>
+                    <p> {{- localise "CookiesNoJSWarn2" .Language 1 -}} </p>
                     <ul>
                         <li>{{- localise "CookiesNoJSOpt1" .Language 1 -}}</li>
                         <li>{{- localise "CookiesNoJSOpt2" .Language 1 -}}</li>
                     </ul>
-                    <p> {{- localise "CookiesNoJSWarn2" .Language 1 -}} </p>
                 </div>
-                <form method="post">
-                    <fieldset class="ons-fieldset cookies-js hidden">
-                        <legend class="ons-fieldset__legend">{{- localise "CookiesUsage" .Language 1 -}}</legend>
-                        <p>{{- localise "CookiesUsageP1" .Language 1 -}}</p>
-                        <ul class="ons-list">
-                            <li class="ons-list__item">{{- localise "CookiesUsageBP1" .Language 1 -}}</li>
-                            <li class="ons-list__item">{{- localise "CookiesUsageBP2" .Language 1 -}}</li>
-                            <li class="ons-list__item">{{- localise "CookiesUsageBP3" .Language 1 -}}</li>
-                            <li class="ons-list__item">{{- localise "CookiesUsageBP4" .Language 1 -}}</li>
-                            <li class="ons-list__item">{{- localise "CookiesUsageBP5" .Language 1 -}}</li>
-                        </ul>
-                        <p>{{- localise "CookiesUsageP2" .Language 1 -}}</p>
-                        {{ template "partials/fields/fieldset-radio" .UsageRadios }}
-                    </fieldset>
-                    
-                    <h3 class="ons-u-mt-s">{{- localise "CookiesEssential" .Language 1 -}}</h3>
 
+                <form class="cookies-js hidden" method="post">
+                    <h3 class="ons-u-mt-l">{{- localise "CookiesUsage" .Language 1 -}}</h3>
+                    <p>{{- localise "CookiesUsageP1" .Language 1 -}}</p>
+                    <ul>
+                        <li>{{- localise "CookiesUsageBP1" .Language 1 -}}</li>
+                        <li>{{- localise "CookiesUsageBP2" .Language 1 -}}</li>
+                        <li>{{- localise "CookiesUsageBP3" .Language 1 -}}</li>
+                        <li>{{- localise "CookiesUsageBP4" .Language 1 -}}</li>
+                        <li>{{- localise "CookiesUsageBP5" .Language 1 -}}</li>
+                    </ul>
+                    <p>{{- localise "CookiesUsageP2" .Language 1 -}}</p>
+                    {{ template "partials/fields/fieldset-radio" .UsageRadios }}
+
+                    <h3 class="ons-u-mt-l">{{- localise "CookiesComms" .Language 1 -}}</h3>
+                    <p>{{- localise "CookiesCommsP1" .Language 1 -}}</p>
+                    <p>{{- localise "CookiesCommsP2" .Language 1 -}}</p>
+                    <h4>{{- localise "CookiesCommsSubHead1" .Language 1 -}}</h4>
+                    <p>{{- localise "CookiesCommsSubP1" .Language 1 -}}</p>
+                    {{ template "partials/fields/fieldset-radio" .CommsRadios }}
+
+                    <h3 class="ons-u-mt-l">{{- localise "CookiesSiteSettings" .Language 1 -}}</h3>
+                    <p>{{- localise "CookiesSiteSettingsP1" .Language 1 -}}</p>
+                    {{ template "partials/fields/fieldset-radio" .SiteSettingsRadios }}
+
+
+                    <h3 class="ons-u-mt-l">{{- localise "CookiesEssential" .Language 1 -}}</h3>
                     <p>{{- localise "CookiesEssentialP1" .Language 1 -}}</p>
+                    <ul>
+                        <li>{{- localise "CookiesEssentialBP1" .Language 1 -}}</li>
+                        <li>{{- localise "CookiesEssentialBP2" .Language 1 -}}</li>
+                    </ul>
 
                     <p>{{- localise "CookiesEssentialP2" .Language 1 -}}</p>
-                    
+
                     <p>{{- localise "CookiesEssentialP3" .Language 1 | safeHTML -}}</p>
 
-                    <button type="submit" class="ons-btn ons-u-mt-xl ons-u-mb-s cookies-js hidden">
+                    <button
+                        type="submit"
+                        class="ons-btn ons-u-mt-m ons-u-mb-s"
+                    >
                         <span class="ons-btn__inner">
-                            <span class="ons-btn__text">{{- localise "SaveChanges" .Language 1 -}}</span>
+                            <span class="ons-btn__text">{{- localise "SaveChanges" .Language 6 -}}</span>
                         </span>
                     </button>
                 </form>
+
             </div>
         </div>
     </div>

--- a/assets/templates/cookies-preferences.tmpl
+++ b/assets/templates/cookies-preferences.tmpl
@@ -14,7 +14,7 @@
                     <span
                         id="alert"
                         class="ons-panel__assistive-text ons-u-vh"
-                    >Completed: </span>
+                    >{{- localise "CookiesPreferencesCompleted" .Language 1 -}}: </span>
                     <div class="ons-panel__body">
                         <h2>{{- localise "CookiesPreferencesSaved" .Language 4 -}}</h2>
                         <p>{{- localise "CookiesPreferencesSavedAmend" .Language 4 | safeHTML -}}</p>
@@ -62,7 +62,6 @@
                     <p>{{- localise "CookiesSiteSettingsP1" .Language 1 -}}</p>
                     {{ template "partials/fields/fieldset-radio" .SiteSettingsRadios }}
 
-
                     <h3 class="ons-u-mt-l">{{- localise "CookiesEssential" .Language 1 -}}</h3>
                     <p>{{- localise "CookiesEssentialP1" .Language 1 -}}</p>
                     <ul>
@@ -83,7 +82,6 @@
                         </span>
                     </button>
                 </form>
-
             </div>
         </div>
     </div>

--- a/ci/scripts/lint
+++ b/ci/scripts/lint
@@ -1,5 +1,0 @@
-#!/bin/bash -eux
-
-pushd dp-frontend-cookie-controller
-  make lint
-popd

--- a/ci/scripts/lint.sh
+++ b/ci/scripts/lint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -eux
 
-pushd dp-frontend-cookie-controller
+cwd=$(pwd)
+
+pushd $cwd/dp-frontend-cookie-controller
+  go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.6
   make lint
 popd

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ONSdigital/dp-healthcheck v1.6.4
 	github.com/ONSdigital/dp-net/v3 v3.3.0
 	github.com/ONSdigital/dp-otel-go v0.0.8
-	github.com/ONSdigital/dp-renderer/v2 v2.21.0
+	github.com/ONSdigital/dp-renderer/v2 v2.23.0
 	github.com/ONSdigital/log.go/v2 v2.4.5
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,10 @@ github.com/ONSdigital/dp-net/v3 v3.3.0 h1:NAH9z+nvbJxoK6OnDpOyJJ+52dqBhVtaugk5bq
 github.com/ONSdigital/dp-net/v3 v3.3.0/go.mod h1:ur4LLCvd2xW2jpa785pElE6HB2bPvszZxdAjqv0XFGg=
 github.com/ONSdigital/dp-otel-go v0.0.8 h1:jSX32oDmOUKlHyH3FPCBkBpiBKYmWKELoNo6jontKRM=
 github.com/ONSdigital/dp-otel-go v0.0.8/go.mod h1:pCDuFqZX8+7CBQX1nMlLMPj52VsMAN3Y8h0uLmzC3cU=
-github.com/ONSdigital/dp-renderer/v2 v2.21.0 h1:sIEn9DoN9V95rnPDX67+32eju48LapYCUiVmo83axOc=
-github.com/ONSdigital/dp-renderer/v2 v2.21.0/go.mod h1:RnpkYyv2/aB7RO1kvd279aiCRabcHf3lllihBNXPNx8=
+github.com/ONSdigital/dp-renderer/v2 v2.22.0 h1:dFk1GJs/IsLIr/XPF1obnuOGekX53d+x8KTiEG6Iupc=
+github.com/ONSdigital/dp-renderer/v2 v2.22.0/go.mod h1:RnpkYyv2/aB7RO1kvd279aiCRabcHf3lllihBNXPNx8=
+github.com/ONSdigital/dp-renderer/v2 v2.23.0 h1:oasZ8qDsF8sJfDahGQDKU8Z5hmEEouJJCxYQRyzpIYc=
+github.com/ONSdigital/dp-renderer/v2 v2.23.0/go.mod h1:RnpkYyv2/aB7RO1kvd279aiCRabcHf3lllihBNXPNx8=
 github.com/ONSdigital/log.go/v2 v2.4.5 h1:LclSJUNHgbhgl386daHXNX9j3LOwXd/AeuiSSfEuclM=
 github.com/ONSdigital/log.go/v2 v2.4.5/go.mod h1:qaWY2DOgD/hIzas3m76WPye1HrrS3RLXQC7erxVL36Y=
 github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500 h1:6lhrsTEnloDPXyeZBvSYvQf8u86jbKehZPVDDlkgDl4=

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -103,21 +103,21 @@ func edit(w http.ResponseWriter, req *http.Request, rendC RenderClient, siteDoma
 	cookiePolicyUsage := req.FormValue("cookie-policy-usage")
 	if cookiePolicyUsage == "" {
 		err := clientErr{errors.New("request form value cookie-policy-usage not found")}
-		log.Error(ctx, "failed to get cookie value cookie-policy-usage from form", err)
+		log.Info(ctx, "failed to get cookie value cookie-policy-usage from form", log.Data{"client_error": err})
 		setStatusCode(req, w, err)
 		return
 	}
 	cookiePolicyComms := req.FormValue("cookie-policy-comms")
 	if cookiePolicyComms == "" {
 		err := clientErr{errors.New("request form value cookie-policy-comms not found")}
-		log.Error(ctx, "failed to get cookie value cookie-policy-comms from form", err)
+		log.Info(ctx, "failed to get cookie value cookie-policy-comms from form", log.Data{"client_error": err})
 		setStatusCode(req, w, err)
 		return
 	}
 	cookiePolicySiteSettings := req.FormValue("cookie-policy-site-settings")
 	if cookiePolicySiteSettings == "" {
 		err := clientErr{errors.New("request form value cookie-policy-site-settings not found")}
-		log.Error(ctx, "failed to get cookie value cookie-policy-site-settings from form", err)
+		log.Info(ctx, "failed to get cookie value cookie-policy-site-settings from form", log.Data{"client_error": err})
 		setStatusCode(req, w, err)
 		return
 	}
@@ -125,19 +125,22 @@ func edit(w http.ResponseWriter, req *http.Request, rendC RenderClient, siteDoma
 	// parse form values and make type safe
 	usage, err := strconv.ParseBool(cookiePolicyUsage)
 	if err != nil {
-		log.Error(ctx, "failed to parse cookie value usage", err)
+		err := clientErr{errors.New("request form value cookie-policy-usage not valid")}
+		log.Info(ctx, "failed to parse cookie value usage", log.Data{"client_error": err})
 		setStatusCode(req, w, err)
 		return
 	}
 	comms, err := strconv.ParseBool(cookiePolicyComms)
 	if err != nil {
-		log.Error(ctx, "failed to parse cookie value comms", err)
+		err := clientErr{errors.New("request form value cookie-policy-comms not valid")}
+		log.Info(ctx, "failed to parse cookie value comms", log.Data{"client_error": err})
 		setStatusCode(req, w, err)
 		return
 	}
 	siteSettings, err := strconv.ParseBool(cookiePolicySiteSettings)
 	if err != nil {
-		log.Error(ctx, "failed to parse cookie value site settings", err)
+		err := clientErr{errors.New("request form value cookie-policy-site-usage not valid")}
+		log.Info(ctx, "failed to parse cookie value site settings", log.Data{"client_error": err})
 		setStatusCode(req, w, err)
 		return
 	}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -152,9 +152,8 @@ func edit(w http.ResponseWriter, req *http.Request, rendC RenderClient, siteDoma
 		Usage:     usage,
 	}
 
-	if !usage {
-		removeNonProtectedCookies(w, req)
-	}
+	// always remove non-protected cookies
+	removeNonProtectedCookies(w, req)
 	cookies.SetONSPreferenceIsSet(w, siteDomain)
 	cookies.SetONSPolicy(w, cp, siteDomain)
 	isUpdated := true

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -86,14 +86,14 @@ func Read(rendC RenderClient) http.HandlerFunc {
 }
 
 // Edit Handler
-func Edit(rendC RenderClient, siteDomain string) http.HandlerFunc {
+func Edit(rendC RenderClient) http.HandlerFunc {
 	return dphandlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, accessToken string) {
-		edit(w, req, rendC, siteDomain, lang)
+		edit(w, req, rendC, lang)
 	})
 }
 
 // edit handler for changing and setting cookie preferences, returns populated cookie preferences page from the renderer
-func edit(w http.ResponseWriter, req *http.Request, rendC RenderClient, siteDomain, lang string) {
+func edit(w http.ResponseWriter, req *http.Request, rendC RenderClient, lang string) {
 	ctx := req.Context()
 	if err := req.ParseForm(); err != nil {
 		log.Error(ctx, "failed to parse form input", err)
@@ -127,8 +127,9 @@ func edit(w http.ResponseWriter, req *http.Request, rendC RenderClient, siteDoma
 
 	// always remove non-protected cookies
 	removeNonProtectedCookies(w, req)
-	cookies.SetONSPreferenceIsSet(w, siteDomain)
-	cookies.SetONSPolicy(w, cp, siteDomain)
+	domain := req.Header.Get("X-Forwarded-Host")
+	cookies.SetONSPreferenceIsSet(w, domain)
+	cookies.SetONSPolicy(w, cp, domain)
 	isUpdated := true
 	getCookiePreferencePage(w, rendC, cp, isUpdated, lang)
 }

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -97,7 +97,7 @@ func TestEditHandler(t *testing.T) {
 			b := `cookie-policy-usage=true&cookie-policy-comms=true&cookie-policy-site-settings=true`
 			req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-			w := doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), nil)
+			w := doTestRequest("/cookies", req, Edit(mockRend), nil)
 			So(w.Code, ShouldEqual, http.StatusOK)
 			cookiePolicyTest(w, cookiesPol)
 		})
@@ -135,7 +135,7 @@ func TestEditHandler(t *testing.T) {
 			http.SetCookie(w, cookieRememberBasket)
 			http.SetCookie(w, cookieTimeSeriesBasket)
 
-			w = doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), w)
+			w = doTestRequest("/cookies", req, Edit(mockRend), w)
 
 			So(w.Code, ShouldEqual, http.StatusOK)
 			cookiePolicyTest(w, essentialSetCookiesPolicy)
@@ -147,7 +147,7 @@ func TestEditHandler(t *testing.T) {
 			b := `cookie-policy-waffles=true`
 			req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-			w := doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), nil)
+			w := doTestRequest("/cookies", req, Edit(mockRend), nil)
 			So(w.Code, ShouldEqual, http.StatusBadRequest)
 		})
 
@@ -156,21 +156,21 @@ func TestEditHandler(t *testing.T) {
 				b := `cookie-policy-usage=&cookie-policy-comms=false&cookie-policy-site-settings=false`
 				req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-				w := doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), nil)
+				w := doTestRequest("/cookies", req, Edit(mockRend), nil)
 				So(w.Code, ShouldEqual, http.StatusBadRequest)
 			})
 			Convey("cookie-policy-comms", func() {
 				b := `cookie-policy-usage=false&cookie-policy-comms=`
 				req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-				w := doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), nil)
+				w := doTestRequest("/cookies", req, Edit(mockRend), nil)
 				So(w.Code, ShouldEqual, http.StatusBadRequest)
 			})
 			Convey("cookie-policy-settings", func() {
 				b := `cookie-policy-usage=false&cookie-policy-comms=false&cookie-policy-site-settings=`
 				req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-				w := doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), nil)
+				w := doTestRequest("/cookies", req, Edit(mockRend), nil)
 				So(w.Code, ShouldEqual, http.StatusBadRequest)
 			})
 		})
@@ -180,21 +180,21 @@ func TestEditHandler(t *testing.T) {
 				b := `cookie-policy-usage=nonbool&cookie-policy-comms=false&cookie-policy-site-settings=false`
 				req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-				w := doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), nil)
+				w := doTestRequest("/cookies", req, Edit(mockRend), nil)
 				So(w.Code, ShouldEqual, http.StatusBadRequest)
 			})
 			Convey("cookie-policy-comms", func() {
 				b := `cookie-policy-usage=false&cookie-policy-comms=blah&cookie-policy-site-settings=false`
 				req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-				w := doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), nil)
+				w := doTestRequest("/cookies", req, Edit(mockRend), nil)
 				So(w.Code, ShouldEqual, http.StatusBadRequest)
 			})
 			Convey("cookie-policy-settings", func() {
 				b := `cookie-policy-usage=false&cookie-policy-comms=false&cookie-policy-site-settings=notbool`
 				req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-				w := doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), nil)
+				w := doTestRequest("/cookies", req, Edit(mockRend), nil)
 				So(w.Code, ShouldEqual, http.StatusBadRequest)
 			})
 		})

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -143,7 +143,7 @@ func TestEditHandler(t *testing.T) {
 			So(allProtectedCookiesFound, ShouldEqual, true)
 		})
 
-		Convey("fail with bad form names", func() {
+		Convey("400 with bad form names", func() {
 			b := `cookie-policy-waffles=true`
 			req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -151,12 +151,52 @@ func TestEditHandler(t *testing.T) {
 			So(w.Code, ShouldEqual, http.StatusBadRequest)
 		})
 
-		Convey("fail with bad form values", func() {
-			b := `cookie-policy-usage=nonbool`
-			req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
-			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-			w := doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), nil)
-			So(w.Code, ShouldEqual, http.StatusBadRequest)
+		Convey("400 with omitted form values", func() {
+			Convey("cookie-policy-usage", func() {
+				b := `cookie-policy-usage=&cookie-policy-comms=false&cookie-policy-site-settings=false`
+				req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				w := doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), nil)
+				So(w.Code, ShouldEqual, http.StatusBadRequest)
+			})
+			Convey("cookie-policy-comms", func() {
+				b := `cookie-policy-usage=false&cookie-policy-comms=`
+				req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				w := doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), nil)
+				So(w.Code, ShouldEqual, http.StatusBadRequest)
+			})
+			Convey("cookie-policy-settings", func() {
+				b := `cookie-policy-usage=false&cookie-policy-comms=false&cookie-policy-site-settings=`
+				req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				w := doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), nil)
+				So(w.Code, ShouldEqual, http.StatusBadRequest)
+			})
+		})
+
+		Convey("400 with bad form values", func() {
+			Convey("cookie-policy-usage", func() {
+				b := `cookie-policy-usage=nonbool&cookie-policy-comms=false&cookie-policy-site-settings=false`
+				req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				w := doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), nil)
+				So(w.Code, ShouldEqual, http.StatusBadRequest)
+			})
+			Convey("cookie-policy-comms", func() {
+				b := `cookie-policy-usage=false&cookie-policy-comms=blah&cookie-policy-site-settings=false`
+				req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				w := doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), nil)
+				So(w.Code, ShouldEqual, http.StatusBadRequest)
+			})
+			Convey("cookie-policy-settings", func() {
+				b := `cookie-policy-usage=false&cookie-policy-comms=false&cookie-policy-site-settings=notbool`
+				req := httptest.NewRequest("POST", "/cookies", bytes.NewBufferString(b))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				w := doTestRequest("/cookies", req, Edit(mockRend, cfg.SiteDomain), nil)
+				So(w.Code, ShouldEqual, http.StatusBadRequest)
+			})
 		})
 	})
 }

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -32,7 +32,7 @@ func TestReadHandler(t *testing.T) {
 			mockRend := NewMockRenderClient(mockCtrl)
 			mockRend.EXPECT().NewBasePageModel().Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain))
 			mockRend.EXPECT().BuildPage(gomock.Any(), gomock.Any(), gomock.Eq("cookies-preferences"))
-			req := httptest.NewRequest("GET", "/cookies", nil)
+			req := httptest.NewRequest("GET", "/cookies", http.NoBody)
 			w := doTestRequest("/cookies", req, Read(mockRend), nil)
 			So(w.Code, ShouldEqual, http.StatusOK)
 		})
@@ -54,7 +54,7 @@ func TestReadHandler(t *testing.T) {
 			mockRend.EXPECT().NewBasePageModel().Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain))
 			mockRend.EXPECT().BuildPage(gomock.Any(), gomock.Any(), gomock.Eq("cookies-preferences"))
 
-			req := httptest.NewRequest("GET", "/cookies", nil)
+			req := httptest.NewRequest("GET", "/cookies", http.NoBody)
 			w = doTestRequest("/cookies", req, Read(mockRend), w)
 			So(w.Code, ShouldEqual, http.StatusOK)
 		})
@@ -278,7 +278,7 @@ func initialiseMockConfig() config.Config {
 func TestUnitHandlers(t *testing.T) {
 	Convey("test setStatusCode", t, func() {
 		Convey("test status code handles 404 response from client", func() {
-			req := httptest.NewRequest("GET", "http://localhost:24100", nil)
+			req := httptest.NewRequest("GET", "http://localhost:24100", http.NoBody)
 			w := httptest.NewRecorder()
 			err := &testCliError{}
 			setStatusCode(req, w, err)

--- a/main.go
+++ b/main.go
@@ -80,6 +80,10 @@ func run(ctx context.Context) error {
 		GitCommit,
 		Version,
 	)
+	if err != nil {
+		log.Error(ctx, "failed to create service version information", err)
+		return err
+	}
 
 	r := mux.NewRouter()
 
@@ -87,7 +91,6 @@ func run(ctx context.Context) error {
 		r.Use(otelmux.Middleware(cfg.OTServiceName))
 	}
 
-	//nolint:typecheck
 	rendC := render.NewWithDefaultClient(assets.Asset, assets.AssetNames, cfg.PatternLibraryAssetsPath, cfg.SiteDomain)
 
 	healthcheck := health.New(versionInfo, cfg.HealthCheckCriticalTimeout, cfg.HealthCheckInterval)
@@ -119,6 +122,7 @@ func run(ctx context.Context) error {
 		}
 	}()
 
+	//nolint:gosimple // ignore this as intention is to continue to listen for signals
 	for {
 		select {
 		case <-signals:

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -11,7 +11,7 @@ const (
 )
 
 // CreateCookieSettingPage maps type cookies.Policy to model.Page
-func CreateCookieSettingPage(basePage coreModel.Page, policy cookies.Policy, isUpdated bool, lang string) model.CookiesPreference {
+func CreateCookieSettingPage(basePage coreModel.Page, policy cookies.ONSPolicy, isUpdated bool, lang string) model.CookiesPreference {
 	page := model.CookiesPreference{
 		Page: basePage,
 	}
@@ -24,8 +24,13 @@ func CreateCookieSettingPage(basePage coreModel.Page, policy cookies.Policy, isU
 	page.Metadata.Title = CookiesStr
 	page.Language = lang
 	page.CookiesPreferencesSet = true
-	page.CookiesPolicy.Essential = policy.Essential
-	page.CookiesPolicy.Usage = policy.Usage
+	page.CookiesPolicy = coreModel.CookiesPolicy{
+		Communications: policy.Campaigns,
+		Essential:      policy.Essential,
+		Settings:       policy.Settings,
+		Usage:          policy.Usage,
+	}
+
 	page.FeatureFlags.HideCookieBanner = true
 
 	// Determine whether or not to show success message. Currently this will
@@ -33,6 +38,7 @@ func CreateCookieSettingPage(basePage coreModel.Page, policy cookies.Policy, isU
 	page.PreferencesUpdated = isUpdated
 
 	page.UsageRadios = coreModel.RadioFieldset{
+		HasBorder: true,
 		Radios: []coreModel.Radio{
 			{
 				Input: coreModel.Input{
@@ -55,6 +61,66 @@ func CreateCookieSettingPage(basePage coreModel.Page, policy cookies.Policy, isU
 						Plural:    1,
 					},
 					Name:  "cookie-policy-usage",
+					Value: "false",
+				},
+			},
+		},
+	}
+
+	page.CommsRadios = coreModel.RadioFieldset{
+		HasBorder: true,
+		Radios: []coreModel.Radio{
+			{
+				Input: coreModel.Input{
+					ID:        "comms-on",
+					IsChecked: page.CookiesPolicy.Communications,
+					Label: coreModel.Localisation{
+						LocaleKey: "On",
+						Plural:    1,
+					},
+					Name:  "cookie-policy-comms",
+					Value: "true",
+				},
+			},
+			{
+				Input: coreModel.Input{
+					ID:        "comms-off",
+					IsChecked: !page.CookiesPolicy.Communications,
+					Label: coreModel.Localisation{
+						LocaleKey: "Off",
+						Plural:    1,
+					},
+					Name:  "cookie-policy-comms",
+					Value: "false",
+				},
+			},
+		},
+	}
+
+	page.SiteSettingsRadios = coreModel.RadioFieldset{
+		HasBorder: true,
+		Radios: []coreModel.Radio{
+			{
+				Input: coreModel.Input{
+					ID:        "site-settings-on",
+					IsChecked: page.CookiesPolicy.Settings,
+					Label: coreModel.Localisation{
+						LocaleKey: "On",
+						Plural:    1,
+					},
+					Name:  "cookie-policy-site-settings",
+					Value: "true",
+				},
+			},
+			{
+				Input: coreModel.Input{
+					ID:        "site-settings-off",
+					IsChecked: !page.CookiesPolicy.Settings,
+					Label: coreModel.Localisation{
+						LocaleKey: "Off",
+						Plural:    1,
+					},
+					Name:  "cookie-policy-site-settings",
 					Value: "false",
 				},
 			},

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -14,9 +14,11 @@ import (
 // TestUnitMapper tests mapper functions
 func TestUnitMapper(t *testing.T) {
 	t.Parallel()
-	cookiesPolicy := cookies.Policy{
+	cookiesPolicy := cookies.ONSPolicy{
+		Campaigns: false,
 		Essential: true,
 		Usage:     false,
+		Settings:  false,
 	}
 	expectedModel := model.CookiesPreference{}
 	expectedModel.Breadcrumb = []coreModel.TaxonomyNode{
@@ -30,11 +32,16 @@ func TestUnitMapper(t *testing.T) {
 	expectedModel.Language = "en"
 	expectedModel.Metadata.Title = CookiesStr
 	expectedModel.CookiesPreferencesSet = true
-	expectedModel.CookiesPolicy.Essential = true
-	expectedModel.CookiesPolicy.Usage = false
+	expectedModel.CookiesPolicy = coreModel.CookiesPolicy{
+		Communications: cookiesPolicy.Campaigns,
+		Essential:      cookiesPolicy.Essential,
+		Settings:       cookiesPolicy.Settings,
+		Usage:          cookiesPolicy.Usage,
+	}
 	expectedModel.PreferencesUpdated = false
 	expectedModel.FeatureFlags.HideCookieBanner = true
 	expectedModel.UsageRadios = coreModel.RadioFieldset{
+		HasBorder: true,
 		Radios: []coreModel.Radio{
 			{
 				Input: coreModel.Input{
@@ -62,7 +69,64 @@ func TestUnitMapper(t *testing.T) {
 			},
 		},
 	}
-
+	expectedModel.CommsRadios = coreModel.RadioFieldset{
+		HasBorder: true,
+		Radios: []coreModel.Radio{
+			{
+				Input: coreModel.Input{
+					ID:        "comms-on",
+					IsChecked: false,
+					Label: coreModel.Localisation{
+						LocaleKey: "On",
+						Plural:    1,
+					},
+					Name:  "cookie-policy-comms",
+					Value: "true",
+				},
+			},
+			{
+				Input: coreModel.Input{
+					ID:        "comms-off",
+					IsChecked: true,
+					Label: coreModel.Localisation{
+						LocaleKey: "Off",
+						Plural:    1,
+					},
+					Name:  "cookie-policy-comms",
+					Value: "false",
+				},
+			},
+		},
+	}
+	expectedModel.SiteSettingsRadios = coreModel.RadioFieldset{
+		HasBorder: true,
+		Radios: []coreModel.Radio{
+			{
+				Input: coreModel.Input{
+					ID:        "site-settings-on",
+					IsChecked: false,
+					Label: coreModel.Localisation{
+						LocaleKey: "On",
+						Plural:    1,
+					},
+					Name:  "cookie-policy-site-settings",
+					Value: "true",
+				},
+			},
+			{
+				Input: coreModel.Input{
+					ID:        "site-settings-off",
+					IsChecked: true,
+					Label: coreModel.Localisation{
+						LocaleKey: "Off",
+						Plural:    1,
+					},
+					Name:  "cookie-policy-site-settings",
+					Value: "false",
+				},
+			},
+		},
+	}
 	basePage := coreModel.NewPage("path/to/assets", "site-domain")
 	Convey("test CreateCookieSettingPage", t, func() {
 		mcp := CreateCookieSettingPage(basePage, cookiesPolicy, false, request.DefaultLang)

--- a/model/cookies-preference.go
+++ b/model/cookies-preference.go
@@ -5,6 +5,8 @@ import "github.com/ONSdigital/dp-renderer/v2/model"
 // CookiesPreference is the model struct for the cookies preferences form
 type CookiesPreference struct {
 	model.Page
+	CommsRadios        model.RadioFieldset `json:"comms_radios"`
 	PreferencesUpdated bool                `json:"preferences_updated"`
+	SiteSettingsRadios model.RadioFieldset `json:"site_settings_radios"`
 	UsageRadios        model.RadioFieldset `json:"usage_radios"`
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -17,5 +17,5 @@ func Init(ctx context.Context, r *mux.Router, hc health.HealthCheck, rendC *rend
 	r.StrictSlash(true).Path("/health").HandlerFunc(hc.Handler)
 
 	r.StrictSlash(true).Path("/cookies").Methods("GET").HandlerFunc(handlers.Read(rendC))
-	r.StrictSlash(true).Path("/cookies").Methods("POST").HandlerFunc(handlers.Edit(rendC, rendC.SiteDomain))
+	r.StrictSlash(true).Path("/cookies").Methods("POST").HandlerFunc(handlers.Edit(rendC))
 }


### PR DESCRIPTION
### What

✅ [Converted cookie consent form](https://service-manual.ons.gov.uk/design-system/patterns/cookies-settings) to (closely) match the [design system pattern](https://jira.ons.gov.uk/browse/DIS-2555) 
- Lifted copy from design system pattern, while keeping some text regarding hotjar
- Expanded form to handle additional expanded policy scope `essential, usage => campaigns, essential, site settings, usage`
- Updated linter and applied fixes
- Changed logging 
- Return 400 for form validation errors

### How to review

- CI checks pass
- Sense check (make sure copy is correct)
- Visual check (compare form with design system pattern) N.B. this is not an exact match, some margins are different
- Run locally (`make debug` on this branch and `make debug` on `dp-design-system`)
  - Check cookie values match form input
  - Check legacy cookie is removed 
  - Check with and without JS

### Who can review

!me
