### PR TITLE
Adjusting default renderer version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ We use v2 of golangci-lint, which you will [need to install](https://golangci-li
 
 | Environment variable         | Config                     | Description                                                                            | Default                       |
 | ---------------------------- | -------------------------- | -------------------------------------------------------------------------------------- | ----------------------------- |
-| APP_RENDERER_VERSION         | RendererVersion            | Defines default version of renderer being used                                         | v0.1.0                        |
 | BIND_ADDR                    | BindAddr                   | The Port to run on                                                                     | :24100                        |
 | SITE_DOMAIN                  | SiteDomain                 |                                                                                        | localhost                     |
 | GRACEFUL_SHUTDOWN_TIMEOUT    | GracefulShutdownTimeout    | Time to wait during graceful shutdown                                                  | 5 seconds                     |

--- a/config/config.go
+++ b/config/config.go
@@ -59,7 +59,6 @@ func get() (*Config, error) {
 		OTServiceName:              "dp-frontend-cookie-controller",
 		OTBatchTimeout:             5 * time.Second,
 		OtelEnabled:                false,
-		RendererVersion:            "v0.1.0",
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,7 +23,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
 				So(cfg.BindAddr, ShouldEqual, ":24100")
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dis-design-system-go/v0.1.0")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dis-design-system-go/")
 				So(cfg.SiteDomain, ShouldEqual, "localhost")
 				So(cfg.OTExporterOTLPEndpoint, ShouldEqual, "localhost:4317")
 				So(cfg.OTServiceName, ShouldEqual, "dp-frontend-cookie-controller")


### PR DESCRIPTION
### What

Removed the default renderer version

### How to review

See if all okay/tests pass

**To test locally:**
- Run [dis-design-system-go](https://github.com/ONSdigital/dis-design-system-go) in a separate terminal
- Pull this branch and run this branch
- Go to [localhost:24100/cookies](http://localhost:24100/cookies) and compare to https://www.ons.gov.uk/cookies
- Check if all looks the same

**To check whether content is being delivered from the CDN:**
- Stop running dis-design-system-go
- In this branch, within the Makefile, line 24, change DEBUG=1 to DEBUG=0
- Run this branch
- Confirm one of the sources is cdn.ons.gov.uk
<img width="812" height="545" alt="image" src="https://github.com/user-attachments/assets/0e0bfe2b-5ea6-486e-8f0c-51556e439dc6" />


### Who can review

not me